### PR TITLE
ext.kotlin_version = '1.5.20'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'in.lazymanstudios.uri_to_file'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
To avoid build error: The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.